### PR TITLE
Prevent active_hash from creating duplicate IDs

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -179,6 +179,7 @@ module ActiveHash
 
       def create(attributes = {})
         record = new(attributes)
+        validate_unique_id(record)
         record.save
         mark_dirty
         record
@@ -188,6 +189,7 @@ module ActiveHash
 
       def create!(attributes = {})
         record = new(attributes)
+        validate_unique_id(record)
         record.save!
         record
       end

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -71,7 +71,7 @@ module ActiveHash
       include ActiveModel::Conversion
     else
       def to_param
-        id.present? ? id.to_s : nil
+        id.present? ? id : nil
       end
     end
 
@@ -130,7 +130,7 @@ module ActiveHash
 
       def exists?(record)
         if record.id.present?
-          record_index[record.id.to_s].present?
+          record_index[record.id].present?
         end
       end
 
@@ -140,7 +140,7 @@ module ActiveHash
         validate_unique_id(record) if dirty
         mark_dirty
 
-        add_to_record_index({ record.id.to_s => @records.length })
+        add_to_record_index({ record.id => @records.length })
         @records << record
       end
 
@@ -172,7 +172,7 @@ module ActiveHash
       private :add_to_record_index
 
       def validate_unique_id(record)
-        raise IdError.new("Duplicate ID found for record #{record.attributes.inspect}") if record_index.has_key?(record.id.to_s)
+        raise IdError.new("Duplicate ID found for record #{record.attributes.inspect}") if record_index.has_key?(record.id)
       end
 
       private :validate_unique_id

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -52,7 +52,7 @@ module ActiveHash
           records.find(&block) # delegate to Enumerable#find if a block is given
         else
           find_by_id(id) || begin
-            raise RecordNotFound.new("Couldn't find #{klass.name} with ID=#{id}", klass.name, "id", id)
+            raise RecordNotFound.new("Couldn't find #{klass.name} with ID=#{id.inspect}", klass.name, "id", id)
           end
       end
     end
@@ -60,7 +60,7 @@ module ActiveHash
     def find_by_id(id)
       return where(id: id).first if query_hash.present?
 
-      index = klass.send(:record_index)[id.to_s] # TODO: Make index in Base publicly readable instead of using send?
+      index = klass.send(:record_index)[id] # TODO: Make index in Base publicly readable instead of using send?
       index and records[index]
     end
 

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1441,6 +1441,14 @@ describe ActiveHash, "Base" do
       expect(Country.dirty).to be_truthy
     end
 
+    it 'raises an error if object with the same id exists' do
+      Country.data = [
+        {:id => 1, :name => "foo"}
+      ]
+
+      expect { Country.create({:id => 1}) }.to raise_error(ActiveHash::IdError, 'Duplicate ID found for record {:id=>1}')
+    end
+
   end
 
   describe "#valid?" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,3 +14,7 @@ require 'active_record' unless SKIP_ACTIVE_RECORD
 Dir["spec/support/**/*.rb"].each { |f|
   require File.expand_path(f)
 }
+
+RSpec.configure do |config|
+  config.filter_run_when_matching :focus
+end


### PR DESCRIPTION
AH doesn't check if the ID is in use during object creation. This leads to a different behaviour between `data=` and multiple calls to the `create` method. 

```bash
(byebug) Models::Point.data = [ {id:1}, {id:1}]
*** ActiveHash::IdError Exception: Duplicate ID found for record {:associated_stops=>[], :id=>1}

nil
(byebug) Models::Point.create({id:1})
#<Models::Point:0x000055f893355e30 @attributes={:id=>1, :associated_stops=>[]}>
(byebug) Models::Point.create({id:1})
#<Models::Point:0x000055f893369b60 @attributes={:id=>1, :associated_stops=>[]}>
(byebug) Models::Point.find(1)
#<Models::Point:0x000055f89330b560 @attributes={:id=>1, :associated_stops=>[]}>  
                ^^^^^^^^^^^^^^^^^^ This is the very first object created by `data=`
```

Due to stringification of IDs it is not possible to retrieve an object if their id happens to be an integer as a string.
```bash
(byebug) Models::Point.create({id:1})
#<Models::Point:0x000055c977b1a918 @attributes={:id=>1, :associated_stops=>[]}>
(byebug) Models::Point.create({id:"1"})
#<Models::Point:0x000055c977b25f98 @attributes={:id=>"1", :associated_stops=>[]}>
(byebug) Models::Point.find("1")
#<Models::Point:0x000055c977b1a918 @attributes={:id=>1, :associated_stops=>[]}>
(byebug) Models::Point.find(1)
#<Models::Point:0x000055c977b1a918 @attributes={:id=>1, :associated_stops=>[]}>
```

The PR removes the ID stringification logic and add a `validate_unique_id` check to the `create` method.